### PR TITLE
Add check for README.md

### DIFF
--- a/pyvelocity/checks/aggregation.py
+++ b/pyvelocity/checks/aggregation.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Generator
 
+from pyvelocity.checks import Check
 from pyvelocity.checks import Result
 from pyvelocity.checks.line_length import LineLength
+from pyvelocity.checks.readme import Readme
 from pyvelocity.checks.using_py_project_toml import UsingPyProjectToml
 from pyvelocity.configurations.aggregation import Configurations
 from pyvelocity.configurations.files.aggregation import ConfigurationFiles
@@ -28,11 +30,11 @@ class Checks:
     """Aggregation of Check."""
 
     def __init__(self, configuration_files: ConfigurationFiles, configurations: Configurations) -> None:
-        checks = [UsingPyProjectToml, LineLength]
+        check_classes: list[type[Check]] = [UsingPyProjectToml, LineLength, Readme]
         self.checks = (
-            check(configuration_files, configurations)
-            for check in checks
-            if check.ID not in configurations.pyvelocity.filter.value
+            check_class(configuration_files, configurations)
+            for check_class in check_classes
+            if check_class.ID not in configurations.pyvelocity.filter.value
         )
 
     def execute(self) -> Generator[Result, None, None]:

--- a/pyvelocity/checks/readme.py
+++ b/pyvelocity/checks/readme.py
@@ -1,0 +1,37 @@
+"""Implements readme check."""
+
+from pyvelocity.checks import Check
+from pyvelocity.checks import Result
+from pyvelocity.configurations.files.sections.project import Project
+
+
+class Readme(Check):
+    """Checks that readme = "README.md" in project section."""
+
+    ID = "readme"
+
+    def execute(self) -> Result:
+        if self.configuration_files.py_project_toml is None:
+            return Result(self.ID, is_ok=False, message="pyproject.toml is required for readme check")
+
+        if self.configuration_files.py_project_toml.project is None:
+            return Result(self.ID, is_ok=False, message="Project section is missing in pyproject.toml")
+        return self.check_readme(self.configuration_files.py_project_toml.project)
+
+    def check_readme(self, project: Project) -> Result:
+        """Checks that readme = "README.md" in project section."""
+        readme_value = project.readme.value
+        if readme_value is None:
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="readme field is missing in [project] section of pyproject.toml",
+            )
+
+        if readme_value != "README.md":
+            message = (
+                f'readme should be "README.md", but found "{readme_value}" in [project] section of pyproject.toml'
+            )
+            return Result(self.ID, is_ok=False, message=message)
+
+        return Result(self.ID, is_ok=True, message="")

--- a/pyvelocity/configurations/files/py_project_toml.py
+++ b/pyvelocity/configurations/files/py_project_toml.py
@@ -10,6 +10,7 @@ from pyvelocity.configurations.files.sections.docformatter import Docformatter
 from pyvelocity.configurations.files.sections.factory import PyProjectTomlSectionFactory
 from pyvelocity.configurations.files.sections.flake8 import Flake8
 from pyvelocity.configurations.files.sections.isort import Isort
+from pyvelocity.configurations.files.sections.project import Project
 from pyvelocity.configurations.files.sections.pylint import PyProjectTomlPylintFactory
 from pyvelocity.configurations.files.sections.pyvelocity import Pyvelocity
 from pyvelocity.configurations.files.sections.ruff import Ruff
@@ -17,6 +18,7 @@ from pyvelocity.configurations.files.sections.ruff import Ruff
 WHERE_PY_PROJECT_TOML = "pyproject.toml"
 
 
+# Reason: Specification of pyproject.toml . pylint: disable=too-many-instance-attributes
 class PyProjectToml(ConfigurationFile):
     """pyproject.toml."""
 
@@ -24,7 +26,7 @@ class PyProjectToml(ConfigurationFile):
         super().__init__()
         parsed_toml = tomli.loads(path_py_project_toml.read_text(encoding="utf-8"))
         node_tool = "tool"
-        tool = parsed_toml[node_tool]
+        tool = parsed_toml.get(node_tool, {})
         self.black = PyProjectTomlSectionFactory.create(self, node_tool, Black, tool)
         self.docformatter = PyProjectTomlSectionFactory.create(self, node_tool, Docformatter, tool)
         self.flake8 = PyProjectTomlSectionFactory.create(self, node_tool, Flake8, tool)
@@ -32,6 +34,9 @@ class PyProjectToml(ConfigurationFile):
         self.pylint = PyProjectTomlPylintFactory.create(self, node_tool, tool)
         self.pyvelocity = PyProjectTomlSectionFactory.create(self, node_tool, Pyvelocity, tool)
         self.ruff = PyProjectTomlSectionFactory.create(self, node_tool, Ruff, tool)
+
+        # Project section is at root level, not under [tool]
+        self.project = PyProjectTomlSectionFactory.create(self, None, Project, parsed_toml)
 
     @property
     def name(self) -> str:

--- a/pyvelocity/configurations/files/sections/factory.py
+++ b/pyvelocity/configurations/files/sections/factory.py
@@ -71,7 +71,7 @@ class PyProjectTomlSectionFactory:
     def create(
         cls,
         py_project_toml: PyProjectToml,
-        node: str,
+        node: str | None,
         class_configuration: type[TypeVarSection],
         tool: dict[str, dict[str, Any] | None],
     ) -> TypeVarSection | None:

--- a/pyvelocity/configurations/files/sections/project.py
+++ b/pyvelocity/configurations/files/sections/project.py
@@ -1,0 +1,16 @@
+"""Implements section for project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pyvelocity.configurations.files.sections import ConfigurationFileParameter
+from pyvelocity.configurations.files.sections import Section
+
+
+@dataclass
+class Project(Section):
+    NAME: ClassVar[str] = "project"
+    LIST_PARAMETER_NAME: ClassVar[list[str]] = ["readme"]
+    readme: ConfigurationFileParameter[str | None]

--- a/tests/checks/test_aggregation.py
+++ b/tests/checks/test_aggregation.py
@@ -52,6 +52,7 @@ class TestChecks:
             "\tdocformatter tool default wrap summaries = 79\n"
             "\tFlake8 tool default max-line-length = 79 (B950 in flake8-bugbear detects: 87)\n"
             "\tPylint tool default max-line-length = 100\n"
-            "\tRuff tool default line-length = 88"
+            "\tRuff tool default line-length = 88\n"
+            "pyproject.toml is required for readme check"
         )
         assert results.is_ok is False

--- a/tests/checks/test_readme.py
+++ b/tests/checks/test_readme.py
@@ -1,0 +1,58 @@
+"""Tests for readme check."""
+
+import pytest
+
+from pyvelocity.checks.readme import Readme
+from pyvelocity.configurations.aggregation import Configurations
+from pyvelocity.configurations.files.aggregation import ConfigurationFiles
+
+
+class TestReadme:
+    """Test for Readme check."""
+
+    @staticmethod
+    @pytest.mark.usefixtures("configured_tmp_path")
+    @pytest.mark.parametrize(
+        ("files", "expect_message", "expect_is_ok"),
+        [
+            (
+                ["pyproject_success.toml", "setup_success.cfg"],
+                "",
+                True,
+            ),
+            (
+                ["pyproject_readme_missing.toml", "setup_success.cfg"],
+                "readme field is missing in [project] section of pyproject.toml",
+                False,
+            ),
+            (
+                ["pyproject_readme_wrong.toml", "setup_success.cfg"],
+                'readme should be "README.md", but found "README.rst" in [project] section of pyproject.toml',
+                False,
+            ),
+            (
+                ["pyproject_no_project.toml", "setup_success.cfg"],
+                "Project section is missing in pyproject.toml",
+                False,
+            ),
+        ],
+    )
+    def test_readme_check(expect_message: str, *, expect_is_ok: bool) -> None:
+        """Tests readme check scenarios."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        readme_check = Readme(configuration_files, configurations)
+        result = readme_check.execute()
+        assert result.message == expect_message
+        assert result.is_ok == expect_is_ok
+
+    @staticmethod
+    @pytest.mark.usefixtures("ch_tmp_path")
+    def test_no_pyproject_toml() -> None:
+        """Tests case when no pyproject.toml exists."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        readme_check = Readme(configuration_files, configurations)
+        result = readme_check.execute()
+        assert result.message == "pyproject.toml is required for readme check"
+        assert result.is_ok is False

--- a/tests/testresources/pyproject_no_project.toml
+++ b/tests/testresources/pyproject_no_project.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.docformatter]
+recursive = true
+wrap-descriptions = 119
+wrap-summaries = 119
+
+[tool.isort]
+line_length = 119
+
+[tool.black]
+line-length = 119
+
+[tool.pylint.format]
+max-line-length = 119

--- a/tests/testresources/pyproject_readme_missing.toml
+++ b/tests/testresources/pyproject_readme_missing.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="pyvelocity"
+version="0.1.0"
+description = "Checks code and settings and ls up advises in point of velocity."
+requires-python = ">=3.5"
+
+[tool.docformatter]
+recursive = true
+wrap-descriptions = 119
+wrap-summaries = 119
+
+[tool.isort]
+line_length = 119
+
+[tool.black]
+line-length = 119
+
+[tool.pylint.format]
+max-line-length = 119

--- a/tests/testresources/pyproject_readme_wrong.toml
+++ b/tests/testresources/pyproject_readme_wrong.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="pyvelocity"
+version="0.1.0"
+description = "Checks code and settings and ls up advises in point of velocity."
+readme = "README.rst"
+requires-python = ">=3.5"
+
+[tool.docformatter]
+recursive = true
+wrap-descriptions = 119
+wrap-summaries = 119
+
+[tool.isort]
+line_length = 119
+
+[tool.black]
+line-length = 119
+
+[tool.pylint.format]
+max-line-length = 119


### PR DESCRIPTION
This pull request adds a new check to ensure that the `readme` field in the `[project]` section of `pyproject.toml` is present and set to `"README.md"`. It introduces the `Readme` check class, updates the aggregation logic to include this check, and adds comprehensive tests for various scenarios related to the `readme` field. The changes also modify configuration parsing to support the `[project]` section at the root level of `pyproject.toml`.

**New check implementation:**

* Introduced the `Readme` check class in `pyvelocity/checks/readme.py`, which verifies that the `[project]` section of `pyproject.toml` contains a `readme` field set to `"README.md"`, and returns descriptive error messages for missing or incorrect values.

**Integration with check aggregation:**

* Updated the `Checks` class in `pyvelocity/checks/aggregation.py` to include the new `Readme` check alongside existing checks, ensuring it runs as part of the aggregated checks. [[1]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8R5-R8) [[2]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8L31-R37)

**Configuration and parsing enhancements:**

* Modified `pyvelocity/configurations/files/py_project_toml.py` to parse the `[project]` section at the root level and expose it via the `project` attribute, enabling checks to access project-specific fields like `readme`. [[1]](diffhunk://#diff-67647c53882276aed3f7418cfd51f6412ae6226786cd755f7ac2bf25bb8e55f3R13-R29) [[2]](diffhunk://#diff-67647c53882276aed3f7418cfd51f6412ae6226786cd755f7ac2bf25bb8e55f3R38-R40)
* Updated the section factory method signature to support root-level sections by allowing `node` to be `None`.
* Added a new `Project` section dataclass to represent the `[project]` section and its `readme` field.

**Testing improvements:**

* Added a dedicated test suite in `tests/checks/test_readme.py` to cover different scenarios: missing `pyproject.toml`, missing `[project]` section, missing `readme` field, and incorrect `readme` value.
* Added new test resource files for these scenarios: `pyproject_no_project.toml`, `pyproject_readme_missing.toml`, and `pyproject_readme_wrong.toml`. [[1]](diffhunk://#diff-21ef9875f501b2db3a0222ee32812e578fb134f8e37e3e897aad520d9d8d1c8dR1-R17) [[2]](diffhunk://#diff-76b5c4ad2b3663158fc41f8a6310777be71249196be6dc8efc412a00d7946825R1-R23) [[3]](diffhunk://#diff-7024a119ba913fd1466a5384292612f2d1848db699e74e7e04f20282027a7c2dR1-R24)
* Updated aggregation check tests to expect the new error message when `pyproject.toml` is missing.