### PR TITLE
Add check for zip_safe=false

### DIFF
--- a/pyvelocity/checks/aggregation.py
+++ b/pyvelocity/checks/aggregation.py
@@ -9,6 +9,7 @@ from pyvelocity.checks.line_length import LineLength
 from pyvelocity.checks.readme import Readme
 from pyvelocity.checks.requires_python import RequiresPython
 from pyvelocity.checks.using_py_project_toml import UsingPyProjectToml
+from pyvelocity.checks.zip_safe_false import ZipSafeFalse
 from pyvelocity.configurations.aggregation import Configurations
 from pyvelocity.configurations.files.aggregation import ConfigurationFiles
 
@@ -32,7 +33,14 @@ class Checks:
     """Aggregation of Check."""
 
     def __init__(self, configuration_files: ConfigurationFiles, configurations: Configurations) -> None:
-        check_classes: list[type[Check]] = [UsingPyProjectToml, LineLength, Readme, RequiresPython, Classifiers]
+        check_classes: list[type[Check]] = [
+            UsingPyProjectToml,
+            LineLength,
+            Readme,
+            RequiresPython,
+            Classifiers,
+            ZipSafeFalse,
+        ]
         self.checks = (
             check_class(configuration_files, configurations)
             for check_class in check_classes

--- a/pyvelocity/checks/zip_safe_false.py
+++ b/pyvelocity/checks/zip_safe_false.py
@@ -1,0 +1,48 @@
+"""Implements zip-safe-false check."""
+
+from pyvelocity.checks import Check
+from pyvelocity.checks import Result
+from pyvelocity.configurations.files.sections.setuptools import Setuptools
+
+
+class ZipSafeFalse(Check):
+    """Check that zip-safe is set to false in setuptools configuration."""
+
+    ID = "zip-safe-false"
+
+    def execute(self) -> Result:
+        """Execute the zip-safe-false check."""
+        if self.configuration_files.py_project_toml is None:
+            return Result(self.ID, is_ok=False, message="pyproject.toml is required for zip-safe-false check")
+
+        if self.configuration_files.py_project_toml.setuptools is None:
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="[tool.setuptools] section is missing in pyproject.toml",
+            )
+
+        return self.check_zip_safe(self.configuration_files.py_project_toml.setuptools)
+
+    def check_zip_safe(self, setuptools: Setuptools) -> Result:
+        """Check that zip-safe is set to false."""
+        zip_safe_value = setuptools.zip_safe.value
+
+        if zip_safe_value is None:
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="zip-safe field is missing in [tool.setuptools] section of pyproject.toml",
+            )
+
+        # Convert to string and lowercase for comparison to handle both "false", "False", bool values, etc.
+        if str(zip_safe_value).lower() != "false":
+            message = (
+                f'zip-safe should be "false", but found "{zip_safe_value}" '
+                "in [tool.setuptools] section of pyproject.toml. "
+                "New users of setuptools should not attempt to create egg files "
+                "using the deprecated build_egg command."
+            )
+            return Result(self.ID, is_ok=False, message=message)
+
+        return Result(self.ID, is_ok=True, message="")

--- a/pyvelocity/configurations/files/py_project_toml.py
+++ b/pyvelocity/configurations/files/py_project_toml.py
@@ -14,6 +14,7 @@ from pyvelocity.configurations.files.sections.project import Project
 from pyvelocity.configurations.files.sections.pylint import PyProjectTomlPylintFactory
 from pyvelocity.configurations.files.sections.pyvelocity import Pyvelocity
 from pyvelocity.configurations.files.sections.ruff import Ruff
+from pyvelocity.configurations.files.sections.setuptools import Setuptools
 
 WHERE_PY_PROJECT_TOML = "pyproject.toml"
 
@@ -34,6 +35,7 @@ class PyProjectToml(ConfigurationFile):
         self.pylint = PyProjectTomlPylintFactory.create(self, node_tool, tool)
         self.pyvelocity = PyProjectTomlSectionFactory.create(self, node_tool, Pyvelocity, tool)
         self.ruff = PyProjectTomlSectionFactory.create(self, node_tool, Ruff, tool)
+        self.setuptools = PyProjectTomlSectionFactory.create(self, node_tool, Setuptools, tool)
 
         # Project section is at root level, not under [tool]
         self.project = PyProjectTomlSectionFactory.create(self, None, Project, parsed_toml)

--- a/pyvelocity/configurations/files/sections/factory.py
+++ b/pyvelocity/configurations/files/sections/factory.py
@@ -77,7 +77,7 @@ class PyProjectTomlSectionFactory:
     ) -> TypeVarSection | None:
         """Creates Section instance for PyProjectToml."""
         config = tool.get(class_configuration.NAME)
-        if not config:
+        if config is None:
             return None
         return SectionFactoryForPyProjectToml(py_project_toml, node, class_configuration, config).create_section()
 

--- a/pyvelocity/configurations/files/sections/setuptools.py
+++ b/pyvelocity/configurations/files/sections/setuptools.py
@@ -1,0 +1,18 @@
+"""Implements section for setuptools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pyvelocity.configurations.files.sections import ConfigurationFileParameter
+from pyvelocity.configurations.files.sections import Section
+
+
+@dataclass
+class Setuptools(Section):
+    """Represents the [tool.setuptools] section in pyproject.toml configuration files."""
+
+    NAME: ClassVar[str] = "setuptools"
+    LIST_PARAMETER_NAME: ClassVar[list[str]] = ["zip-safe"]
+    zip_safe: ConfigurationFileParameter[str | None]

--- a/tests/checks/test_aggregation.py
+++ b/tests/checks/test_aggregation.py
@@ -60,6 +60,7 @@ class TestChecks:
             "\tRuff tool default line-length = 88\n"
             "pyproject.toml is required for readme check\n"
             "pyproject.toml is required for requires-python check\n"
-            "pyproject.toml is required for classifiers check"
+            "pyproject.toml is required for classifiers check\n"
+            "pyproject.toml is required for zip-safe-false check"
         )
         assert results.is_ok is False

--- a/tests/checks/test_zip_safe_false.py
+++ b/tests/checks/test_zip_safe_false.py
@@ -1,0 +1,99 @@
+"""Tests for zip-safe-false check."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pyvelocity.checks.zip_safe_false import ZipSafeFalse
+from pyvelocity.configurations.aggregation import Configurations
+from pyvelocity.configurations.files.aggregation import ConfigurationFiles
+
+
+class TestZipSafeFalse:
+    """Test for ZipSafeFalse check."""
+
+    @staticmethod
+    @pytest.mark.usefixtures("configured_tmp_path")
+    @pytest.mark.parametrize(
+        ("files", "expect_message", "expect_is_ok"),
+        [
+            (
+                ["pyproject_setuptools_zip_safe_false.toml", "setup_success.cfg"],
+                "",
+                True,
+            ),
+            (
+                ["pyproject_setuptools_zip_safe_true.toml", "setup_success.cfg"],
+                (
+                    'zip-safe should be "false", but found "true" '
+                    "in [tool.setuptools] section of pyproject.toml. "
+                    "New users of setuptools should not attempt to create egg files "
+                    "using the deprecated build_egg command."
+                ),
+                False,
+            ),
+            (
+                ["pyproject_setuptools_zip_safe_missing.toml", "setup_success.cfg"],
+                "zip-safe field is missing in [tool.setuptools] section of pyproject.toml",
+                False,
+            ),
+            (
+                ["pyproject_setuptools_missing.toml", "setup_success.cfg"],
+                "[tool.setuptools] section is missing in pyproject.toml",
+                False,
+            ),
+        ],
+    )
+    def test_zip_safe_false_check(expect_message: str, *, expect_is_ok: bool) -> None:
+        """Tests zip-safe-false check scenarios."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        zip_safe_false_check = ZipSafeFalse(configuration_files, configurations)
+        result = zip_safe_false_check.execute()
+        assert result.message == expect_message
+        assert result.is_ok == expect_is_ok
+
+    @staticmethod
+    @pytest.mark.usefixtures("ch_tmp_path")
+    def test_no_pyproject_toml() -> None:
+        """Tests case when no pyproject.toml exists."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        zip_safe_false_check = ZipSafeFalse(configuration_files, configurations)
+        result = zip_safe_false_check.execute()
+        assert result.message == "pyproject.toml is required for zip-safe-false check"
+        assert result.is_ok is False
+
+
+class TestZipSafeFalseValueHandling:
+    """Test value handling logic for ZipSafeFalse."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "zip_safe_value",
+        ["false", "False", "FALSE"],
+    )
+    def test_zip_safe_accepts_false_values(zip_safe_value: str) -> None:
+        """Test zip-safe accepts 'false' values (case insensitive)."""
+        zip_safe_false_check = ZipSafeFalse(None, None)  # type: ignore[arg-type]
+        mock_setuptools = Mock()
+        mock_setuptools.zip_safe.value = zip_safe_value
+
+        result = zip_safe_false_check.check_zip_safe(mock_setuptools)
+        assert result.is_ok is True
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "zip_safe_value",
+        ["true", "True", "TRUE", "1", "0", "yes", "no"],
+    )
+    def test_zip_safe_rejects_non_false_values(zip_safe_value: str) -> None:
+        """Test zip-safe rejects non-'false' values."""
+        zip_safe_false_check = ZipSafeFalse(None, None)  # type: ignore[arg-type]
+        mock_setuptools = Mock()
+        mock_setuptools.zip_safe.value = zip_safe_value
+
+        result = zip_safe_false_check.check_zip_safe(mock_setuptools)
+        assert result.is_ok is False
+        assert "zip-safe should be" in result.message
+        assert "deprecated build_egg command" in result.message

--- a/tests/testresources/pyproject_setuptools_missing.toml
+++ b/tests/testresources/pyproject_setuptools_missing.toml
@@ -1,0 +1,8 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = "Test project"
+readme = "README.md"
+requires-python = ">=3.9"
+
+# [tool.setuptools] section is missing

--- a/tests/testresources/pyproject_setuptools_zip_safe_false.toml
+++ b/tests/testresources/pyproject_setuptools_zip_safe_false.toml
@@ -1,0 +1,9 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = "Test project"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.setuptools]
+zip-safe = "false"

--- a/tests/testresources/pyproject_setuptools_zip_safe_missing.toml
+++ b/tests/testresources/pyproject_setuptools_zip_safe_missing.toml
@@ -1,0 +1,9 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = "Test project"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.setuptools]
+# zip-safe is missing

--- a/tests/testresources/pyproject_setuptools_zip_safe_true.toml
+++ b/tests/testresources/pyproject_setuptools_zip_safe_true.toml
@@ -1,0 +1,9 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = "Test project"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.setuptools]
+zip-safe = "true"


### PR DESCRIPTION
This pull request introduces a new check to the `pyvelocity` tool that verifies the `[tool.setuptools] zip-safe` field in `pyproject.toml` is set to `"false"`, in line with modern Python packaging recommendations. The implementation includes the new check class, updates to configuration parsing, and comprehensive tests for various scenarios.

**New zip-safe-false check:**

* Added the `ZipSafeFalse` check class, which ensures that the `[tool.setuptools] zip-safe` field in `pyproject.toml` is present and set to `"false"`. The check provides detailed error messages for missing files, sections, or incorrect values.
* Added a new section class `Setuptools` to represent and parse the `[tool.setuptools]` section, and updated configuration file parsing to include this section. [[1]](diffhunk://#diff-69f5fcac8e37c850d4b8b123cd505e4b7657f623dcec0797695a440cc0d9e041R1-R18) [[2]](diffhunk://#diff-67647c53882276aed3f7418cfd51f6412ae6226786cd755f7ac2bf25bb8e55f3R17) [[3]](diffhunk://#diff-67647c53882276aed3f7418cfd51f6412ae6226786cd755f7ac2bf25bb8e55f3R38) [[4]](diffhunk://#diff-c23da85dc69c872837b06742602ac4ca740990d8c09a9d0f6dcbc982d252cc96L80-R80)

**Integration and aggregation:**

* Registered the new `ZipSafeFalse` check in the main aggregation logic, so it runs as part of the overall checks suite. [[1]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8R12) [[2]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8L35-R43)

**Testing:**

* Added a dedicated test suite for the `ZipSafeFalse` check, covering scenarios such as missing `pyproject.toml`, missing `[tool.setuptools]` section, missing `zip-safe` field, and various accepted/rejected values for `zip-safe`.
* Updated aggregation tests to expect the new error message when `pyproject.toml` is missing.
* Added new test resource files for different configurations of `pyproject.toml` to support the tests. [[1]](diffhunk://#diff-b18c180d76b457b460494e546657db77d23b283a973c7d8ab2f719b4c001af99R1-R8) [[2]](diffhunk://#diff-10bd09899499ec573e7e6fb3d2c05cf4d6b9913e62246a7335ab0d05cfc1a4d2R1-R9) [[3]](diffhunk://#diff-c70c1bfbeb9324d2452ccb7b2911856115f6d3711d582825ce721b318fc84580R1-R9) [[4]](diffhunk://#diff-78771d85dcb7b02b59a3be406924ea334598408c75163c2d8977ede6b8af6188R1-R9)