### PR TITLE
Add check for keywords in project block

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Ensures that the `requires-python` field supports the latest stable Python versi
 
 Checks that the `readme` field is properly configured as `"README.md"` in the `[project]` section of `pyproject.toml`.
 
+#### `keywords`
+
+Ensures that at least one keyword is defined in the `[project]` section of `pyproject.toml`. Keywords help improve package discoverability on PyPI and other package indexes.
+
 ### Package Configuration Checks
 
 #### `zip-safe-false`
@@ -114,6 +118,7 @@ Available check IDs:
 - `classifiers`
 - `requires-python`
 - `readme`
+- `keywords`
 - `zip-safe-false`
 - `typed`
 

--- a/pyvelocity/checks/aggregation.py
+++ b/pyvelocity/checks/aggregation.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from pyvelocity.checks import Check
 from pyvelocity.checks import Result
 from pyvelocity.checks.classifiers import Classifiers
+from pyvelocity.checks.keywords import Keywords
 from pyvelocity.checks.line_length import LineLength
 from pyvelocity.checks.readme import Readme
 from pyvelocity.checks.requires_python import RequiresPython
@@ -42,6 +43,7 @@ class Checks:
             Classifiers,
             ZipSafeFalse,
             Typed,
+            Keywords,
         ]
         self.checks = (
             check_class(configuration_files, configurations)

--- a/pyvelocity/checks/keywords.py
+++ b/pyvelocity/checks/keywords.py
@@ -1,0 +1,47 @@
+"""Implements keywords check."""
+
+from pyvelocity.checks import Check
+from pyvelocity.checks import Result
+from pyvelocity.configurations.files.sections.project import Project
+
+
+class Keywords(Check):
+    """Checks that at least one keyword is defined in the project section."""
+
+    ID = "keywords"
+
+    def execute(self) -> Result:
+        if self.configuration_files.py_project_toml is None:
+            return Result(self.ID, is_ok=False, message="pyproject.toml is required for keywords check")
+
+        if self.configuration_files.py_project_toml.project is None:
+            return Result(self.ID, is_ok=False, message="Project section is missing in pyproject.toml")
+
+        return self.check_keywords(self.configuration_files.py_project_toml.project)
+
+    def check_keywords(self, project: Project) -> Result:
+        """Checks that at least one keyword is defined in the project section."""
+        keywords_value = project.keywords.value
+
+        if keywords_value is None:
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="keywords field is missing in [project] section of pyproject.toml",
+            )
+
+        if not isinstance(keywords_value, list):
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="keywords field must be a list in [project] section of pyproject.toml",
+            )
+
+        if len(keywords_value) == 0:
+            return Result(
+                self.ID,
+                is_ok=False,
+                message="At least one keyword must be defined in [project] section of pyproject.toml",
+            )
+
+        return Result(self.ID, is_ok=True, message="")

--- a/pyvelocity/configurations/files/sections/project.py
+++ b/pyvelocity/configurations/files/sections/project.py
@@ -138,10 +138,11 @@ class Project(Section):
     """Represents the [project] section in pyproject.toml configuration files."""
 
     NAME: ClassVar[str] = "project"
-    LIST_PARAMETER_NAME: ClassVar[list[str]] = ["readme", "requires-python", "classifiers"]
+    LIST_PARAMETER_NAME: ClassVar[list[str]] = ["readme", "requires-python", "classifiers", "keywords"]
     readme: ConfigurationFileParameter[str | None]
     requires_python: ConfigurationFileParameter[str | None]
     classifiers: ConfigurationFileParameter[list[str] | None]
+    keywords: ConfigurationFileParameter[list[str] | None]
 
     def requires_python_minimum_version(self) -> str | None:
         """Extract the minimum version from requires-python specification."""

--- a/tests/checks/test_aggregation.py
+++ b/tests/checks/test_aggregation.py
@@ -64,6 +64,7 @@ class TestChecks:
             "pyproject.toml is required for zip-safe-false check\n"
             'Missing tool.setuptools.package-data "*" = ["py.typed"] configuration\n'
             "Missing py.typed files in package directories\n"
-            'Missing "Typing :: Typed" classifier in pyproject.toml'
+            'Missing "Typing :: Typed" classifier in pyproject.toml\n'
+            "pyproject.toml is required for keywords check"
         )
         assert results.is_ok is False

--- a/tests/checks/test_keywords.py
+++ b/tests/checks/test_keywords.py
@@ -1,0 +1,63 @@
+"""Tests for keywords check."""
+
+import pytest
+
+from pyvelocity.checks.keywords import Keywords
+from pyvelocity.configurations.aggregation import Configurations
+from pyvelocity.configurations.files.aggregation import ConfigurationFiles
+
+
+class TestKeywords:
+    """Test for Keywords check."""
+
+    @staticmethod
+    @pytest.mark.usefixtures("configured_tmp_path")
+    @pytest.mark.parametrize(
+        ("files", "expect_message", "expect_is_ok"),
+        [
+            (
+                ["pyproject_success.toml", "setup_success.cfg"],
+                "",
+                True,
+            ),
+            (
+                ["pyproject_keywords_missing.toml", "setup_success.cfg"],
+                "keywords field is missing in [project] section of pyproject.toml",
+                False,
+            ),
+            (
+                ["pyproject_keywords_empty.toml", "setup_success.cfg"],
+                "At least one keyword must be defined in [project] section of pyproject.toml",
+                False,
+            ),
+            (
+                ["pyproject_keywords_invalid_type.toml", "setup_success.cfg"],
+                "keywords field must be a list in [project] section of pyproject.toml",
+                False,
+            ),
+            (
+                ["pyproject_no_project.toml", "setup_success.cfg"],
+                "Project section is missing in pyproject.toml",
+                False,
+            ),
+        ],
+    )
+    def test_keywords_check(expect_message: str, *, expect_is_ok: bool) -> None:
+        """Tests keywords check scenarios."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        keywords_check = Keywords(configuration_files, configurations)
+        result = keywords_check.execute()
+        assert result.message == expect_message
+        assert result.is_ok == expect_is_ok
+
+    @staticmethod
+    @pytest.mark.usefixtures("ch_tmp_path")
+    def test_no_pyproject_toml() -> None:
+        """Tests case when no pyproject.toml exists."""
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        keywords_check = Keywords(configuration_files, configurations)
+        result = keywords_check.execute()
+        assert result.message == "pyproject.toml is required for keywords check"
+        assert result.is_ok is False

--- a/tests/configurations/files/sections/test_project.py
+++ b/tests/configurations/files/sections/test_project.py
@@ -25,6 +25,7 @@ class TestProjectVersionLogic:
             readme=ConfigurationFileParameter(mock_where, "readme", None),
             requires_python=ConfigurationFileParameter(mock_where, "requires-python", requires_python_value),
             classifiers=ConfigurationFileParameter(mock_where, "classifiers", None),
+            keywords=ConfigurationFileParameter(mock_where, "keywords", None),
         )
 
     @staticmethod
@@ -175,6 +176,7 @@ class TestRequiresPythonAnalyzer:
             readme=Mock(),
             requires_python=ConfigurationFileParameter(WhereToolDefault(Mock()), "requires-python", None),
             classifiers=Mock(),
+            keywords=Mock(),
         )
 
         result = project.get_requires_python_supported_versions(project)

--- a/tests/testresources/pyproject_keywords_empty.toml
+++ b/tests/testresources/pyproject_keywords_empty.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="pyvelocity"
+version="0.1.0"
+description = "Checks code and settings and ls up advises in point of velocity."
+readme = "README.md"
+requires-python = ">=3.5"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Yukihiko Shinoda"},
+    {email = "yuk.hik.future@gmail.com"},
+]
+keywords = []
+classifiers=[
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed"
+]
+
+[tool.setuptools]
+zip-safe = false
+packages = ["pyvelocity"]

--- a/tests/testresources/pyproject_keywords_invalid_type.toml
+++ b/tests/testresources/pyproject_keywords_invalid_type.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="pyvelocity"
+version="0.1.0"
+description = "Checks code and settings and ls up advises in point of velocity."
+readme = "README.md"
+requires-python = ">=3.5"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Yukihiko Shinoda"},
+    {email = "yuk.hik.future@gmail.com"},
+]
+keywords = "not-a-list"
+classifiers=[
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed"
+]
+
+[tool.setuptools]
+zip-safe = false
+packages = ["pyvelocity"]

--- a/tests/testresources/pyproject_keywords_missing.toml
+++ b/tests/testresources/pyproject_keywords_missing.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="pyvelocity"
+version="0.1.0"
+description = "Checks code and settings and ls up advises in point of velocity."
+readme = "README.md"
+requires-python = ">=3.5"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Yukihiko Shinoda"},
+    {email = "yuk.hik.future@gmail.com"},
+]
+classifiers=[
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed"
+]
+
+[tool.setuptools]
+zip-safe = false
+packages = ["pyvelocity"]


### PR DESCRIPTION
This pull request introduces a new check to ensure that the `keywords` field is properly defined in the `[project]` section of `pyproject.toml`. This addition improves package metadata validation and helps enhance discoverability on PyPI. The update includes code changes to support the new check, updates to documentation, and comprehensive tests for various scenarios.

**Keywords check implementation and integration:**

* Added a new `Keywords` check in `pyvelocity/checks/keywords.py` to validate that at least one keyword is defined as a list in the `[project]` section of `pyproject.toml`.
* Integrated the `Keywords` check into the check aggregation system in `pyvelocity/checks/aggregation.py`, ensuring it runs with other checks. [[1]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8R8) [[2]](diffhunk://#diff-a7711c690c0443b88bba6db1c7b5b83d3b37e43d75fbd104b94d8a2823d009d8R46)

**Project section model update:**

* Updated the `Project` section model in `pyvelocity/configurations/files/sections/project.py` to support the `keywords` field and treat it as a list parameter.

**Documentation improvements:**

* Updated `README.md` to document the new `keywords` check, its purpose, and its availability in the list of check IDs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121)

**Testing:**

* Added a dedicated test suite for the `Keywords` check in `tests/checks/test_keywords.py`, covering cases such as missing, empty, invalid type, and absent project sections.
* Added and updated test resources for various `keywords` field scenarios (`pyproject_keywords_missing.toml`, `pyproject_keywords_empty.toml`, `pyproject_keywords_invalid_type.toml`). [[1]](diffhunk://#diff-9c6ca6d4333d8d7a9922f7f71e81f9403a06edccac3f57be70999f939ba3212fR1-R25) [[2]](diffhunk://#diff-068878be520845b1a4594afb3695499dc9b3a8b4a6f784597b9feb79fd70603bR1-R26) [[3]](diffhunk://#diff-91e38e0903eb493c1939bd1fc6e6034ad35976301cc1282c3f46b09702c0bad2R1-R26)
* Updated existing tests to include the new `keywords` field where appropriate. [[1]](diffhunk://#diff-0bbec606d6101a65d1b606abb4b901e079d509061abb81c0662e4e4014560867L67-R68) [[2]](diffhunk://#diff-9913dfe92a947a8e2918f838cfb40d71c98ca9d509464ba50b66cdd11fb65126R28) [[3]](diffhunk://#diff-9913dfe92a947a8e2918f838cfb40d71c98ca9d509464ba50b66cdd11fb65126R179)