### PR TITLE
Hotfix qlty

### DIFF
--- a/pyvelocity/regex/qlty.py
+++ b/pyvelocity/regex/qlty.py
@@ -7,10 +7,7 @@ from pyvelocity.regex.markdown import RegexPatternsMarkDown
 class RegexPatternsQlty:
     """Qlty-specific regex patterns for code quality badges."""
 
-    PROJECT_ID = r"[a-zA-Z0-9_.-]+"
-    URL_PROJECT_PAGE = (
-        rf"https://qlty\.sh/gh/{RegexPatternsGitHub.USER}/{RegexPatternsGitHub.REPOSITORY}/projects/{PROJECT_ID}"
-    )
+    URL_PROJECT_PAGE = rf"https://qlty\.sh/gh/{RegexPatternsGitHub.USER}/projects/{RegexPatternsGitHub.REPOSITORY}"
     URL_COVERAGE_BADGE = rf"{URL_PROJECT_PAGE}/coverage\.svg"
     URL_MAINTAINABILITY_BADGE = rf"{URL_PROJECT_PAGE}/maintainability\.svg"
 

--- a/tests/checks/test_badges.py
+++ b/tests/checks/test_badges.py
@@ -25,18 +25,32 @@ class TestBadges:
 
     @staticmethod
     @pytest.mark.usefixtures("ch_tmp_path")
-    def test_all_badges_present() -> None:
+    @pytest.mark.parametrize(
+        "readme_content",
+        [  # Reason: For readability. pylint: disable=line-too-long
+            """
+            # Project
+            [![Test](https://github.com/user/repo/workflows/Test/badge.svg)](https://github.com/user/repo/actions?query=workflow%3ATest)
+            [![CodeQL](https://github.com/user/repo/workflows/CodeQL/badge.svg)](https://github.com/user/repo/actions?query=workflow%3ACodeQL)
+            [![Code Coverage](https://qlty.sh/gh/user/projects/project123/coverage.svg)](https://qlty.sh/gh/user/projects/project123)
+            [![Maintainability](https://qlty.sh/gh/user/projects/project123/maintainability.svg)](https://qlty.sh/gh/user/projects/project123)
+            [![Dependabot](https://flat.badgen.net/github/dependabot/user/repo?icon=dependabot)](https://github.com/user/repo/security/dependabot)
+            [![Python versions](https://img.shields.io/pypi/pyversions/package.svg)](https://pypi.org/project/package/)
+            [![X URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fuser%2Frepo)](https://x.com/intent/post?text=Check%20out%20this%20project&url=https%3A%2F%2Fpypi.org%2Fproject%2Fpackage%2F&hashtags=python)
+            """,
+            """
+            [![Test](https://github.com/yukihiko-shinoda/god-slayer/workflows/Test/badge.svg)](https://github.com/yukihiko-shinoda/god-slayer/actions?query=workflow%3ATest)
+            [![CodeQL](https://github.com/yukihiko-shinoda/god-slayer/workflows/CodeQL/badge.svg)](https://github.com/yukihiko-shinoda/god-slayer/actions?query=workflow%3ACodeQL)
+            [![Code Coverage](https://qlty.sh/gh/yukihiko-shinoda/projects/god-slayer/coverage.svg)](https://qlty.sh/gh/yukihiko-shinoda/projects/god-slayer)
+            [![Maintainability](https://qlty.sh/gh/yukihiko-shinoda/projects/god-slayer/maintainability.svg)](https://qlty.sh/gh/yukihiko-shinoda/projects/god-slayer)
+            [![Dependabot](https://flat.badgen.net/github/dependabot/yukihiko-shinoda/god-slayer?icon=dependabot)](https://github.com/yukihiko-shinoda/god-slayer/security/dependabot)
+            [![Python versions](https://img.shields.io/pypi/pyversions/godslayer.svg)](https://pypi.org/project/godslayer)
+            [![X URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fyukihiko-shinoda%2Fgod-slayer)](https://x.com/intent/post?text=God%20Slayer&url=https%3A%2F%2Fpypi.org%2Fproject%2Fgodslayer%2F&hashtags=python)
+            """,
+        ],
+    )
+    def test_all_badges_present(readme_content: str) -> None:
         """Tests case when all badges are present in README.md."""
-        readme_content = """
-        # Project
-        [![Test](https://github.com/user/repo/workflows/Test/badge.svg)](https://github.com/user/repo/actions?query=workflow%3ATest)
-        [![CodeQL](https://github.com/user/repo/workflows/CodeQL/badge.svg)](https://github.com/user/repo/actions?query=workflow%3ACodeQL)
-        [![Code Coverage](https://qlty.sh/gh/user/repo/projects/project123/coverage.svg)](https://qlty.sh/gh/user/repo/projects/project123)
-        [![Maintainability](https://qlty.sh/gh/user/repo/projects/project123/maintainability.svg)](https://qlty.sh/gh/user/repo/projects/project123)
-        [![Dependabot](https://flat.badgen.net/github/dependabot/user/repo?icon=dependabot)](https://github.com/user/repo/security/dependabot)
-        [![Python versions](https://img.shields.io/pypi/pyversions/package.svg)](https://pypi.org/project/package/)
-        [![X URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fuser%2Frepo)](https://x.com/intent/post?text=Check%20out%20this%20project&url=https%3A%2F%2Fpypi.org%2Fproject%2Fpackage%2F&hashtags=python)
-        """
         Path("README.md").write_text(readme_content, encoding="utf-8")
 
         configuration_files = ConfigurationFiles()

--- a/tests/checks/test_badges.py
+++ b/tests/checks/test_badges.py
@@ -59,3 +59,23 @@ class TestBadges:
         result = badges_check.execute()
         assert result.message == ""
         assert result.is_ok is True
+
+    @staticmethod
+    @pytest.mark.usefixtures("ch_tmp_path")
+    def test_missing_badges() -> None:
+        """Tests case when some badges are missing from README.md."""
+        readme_content = """
+        # Project
+        [![Test](https://github.com/user/repo/workflows/Test/badge.svg)](https://github.com/user/repo/actions?query=workflow%3ATest)
+        """
+        Path("README.md").write_text(readme_content, encoding="utf-8")
+
+        configuration_files = ConfigurationFiles()
+        configurations = Configurations(configuration_files)
+        badges_check = Badges(configuration_files, configurations)
+        result = badges_check.execute()
+
+        assert result.is_ok is False
+        assert "README.md is missing the following badges:" in result.message
+        assert "CodeQL badge" in result.message
+        assert "Code Coverage badge" in result.message


### PR DESCRIPTION
This pull request updates the handling of Qlty badge URLs and improves test coverage for badge detection in README files. The main changes include simplifying the Qlty badge URL regex pattern and enhancing the badge presence tests to cover multiple scenarios, including missing badges.

**Regex pattern update:**

* Simplified the `URL_PROJECT_PAGE` regex in `RegexPatternsQlty` to remove the `PROJECT_ID` variable, aligning the pattern with the updated badge URL format. (`pyvelocity/regex/qlty.py`)

**Test improvements:**

* Refactored `test_all_badges_present` to use `pytest.mark.parametrize`, allowing the test to check multiple README content variations for badge presence. (`tests/checks/test_badges.py`)
* Added a new test, `test_missing_badges`, to verify that the badge check correctly identifies missing badges and provides appropriate error messages. (`tests/checks/test_badges.py`)