### PR TITLE
Support Python 3.14

### DIFF
--- a/pyvelocity/constants.py
+++ b/pyvelocity/constants.py
@@ -1,3 +1,3 @@
 """Constants used throughout PyVelocity."""
 
-LATEST_PYTHON_VERSION = "3.13"
+LATEST_PYTHON_VERSION = "3.14"

--- a/tests/checks/test_aggregation.py
+++ b/tests/checks/test_aggregation.py
@@ -31,7 +31,8 @@ class TestChecks:
                     "Programming Language :: Python :: 3.10, "
                     "Programming Language :: Python :: 3.11, "
                     "Programming Language :: Python :: 3.12, "
-                    "Programming Language :: Python :: 3.13\n"
+                    "Programming Language :: Python :: 3.13, "
+                    "Programming Language :: Python :: 3.14\n"
                     "README.md file not found"
                 ),
                 False,

--- a/tests/checks/test_classifiers.py
+++ b/tests/checks/test_classifiers.py
@@ -33,7 +33,7 @@ class TestClassifiers:
             (
                 ["pyproject_classifier_mismatch_missing.toml", "setup_success.cfg"],
                 "Python version classifiers don't match requires-python '>=3.10': missing classifiers: "
-                "Programming Language :: Python :: 3.12, Programming Language :: Python :: 3.13",
+                "Programming Language :: Python :: 3.12, Programming Language :: Python :: 3.13, Programming Language :: Python :: 3.14",
                 False,
             ),
             (

--- a/tests/checks/test_requires_python.py
+++ b/tests/checks/test_requires_python.py
@@ -28,8 +28,8 @@ class TestRequiresPython:
             (
                 ["pyproject_python_old_requires.toml", "setup_success.cfg"],
                 (
-                    "requires-python should support Python 3.13, "
-                    'but found ">=3.14" in [project] section of pyproject.toml'
+                    "requires-python should support Python 3.14, "
+                    'but found ">=3.15" in [project] section of pyproject.toml'
                 ),
                 False,
             ),
@@ -70,17 +70,17 @@ class TestRequiresPythonVersionLogic:
     @pytest.mark.parametrize(
         ("requires_python_spec", "expected_supports_latest"),
         [
-            # Should support 3.13
+            # Should support 3.14
             (">=3.8", True),
-            (">=3.13", True),
+            (">=3.14", True),
             (">=3.8,<4.0", True),
-            ("~=3.13", True),
-            ("3.13", True),
-            # Should not support 3.13
-            (">=3.14", False),
-            (">=3.8,<3.13", False),
-            ("~=3.12", False),
-            ("3.12", False),
+            ("~=3.14", True),
+            ("3.14", True),
+            # Should not support 3.14
+            (">=3.15", False),
+            (">=3.8,<3.14", False),
+            ("~=3.13", False),
+            ("3.13", False),
             ("invalid", False),
         ],
     )

--- a/tests/configurations/files/sections/test_project.py
+++ b/tests/configurations/files/sections/test_project.py
@@ -33,11 +33,11 @@ class TestProjectVersionLogic:
         ("requires_python_value", "expected_versions"),
         [
             # Test version requirement parsing for Python 3.10 and above
-            (">=3.10", {"3.10", "3.11", "3.12", "3.13"}),
+            (">=3.10", {"3.10", "3.11", "3.12", "3.13", "3.14"}),
             # Test version range with upper bound
             (">=3.8,<3.12", {"3.8", "3.9", "3.10", "3.11"}),
             # Test minimum version requirement including older versions
-            (">=3.5", {"3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"}),
+            (">=3.5", {"3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"}),
             # Test compatible release operator
             ("~=3.11", {"3.11"}),
             # Test exact version specification

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,8 @@ def test_echo_success_in_subprocess(temp_setup_py: Path) -> None:
                 "Programming Language :: Python :: 3.10, "
                 "Programming Language :: Python :: 3.11, "
                 "Programming Language :: Python :: 3.12, "
-                "Programming Language :: Python :: 3.13\n"
+                "Programming Language :: Python :: 3.13, "
+                "Programming Language :: Python :: 3.14\n"
                 "README.md file not found\n"
                 "Error: Looks there are some of improvements.\n"
             ),

--- a/tests/testresources/pyproject_classifier_mismatch_extra.toml
+++ b/tests/testresources/pyproject_classifier_mismatch_extra.toml
@@ -16,6 +16,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.docformatter]

--- a/tests/testresources/pyproject_classifier_missing_requires_python.toml
+++ b/tests/testresources/pyproject_classifier_missing_requires_python.toml
@@ -14,6 +14,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.docformatter]

--- a/tests/testresources/pyproject_python_missing_requires.toml
+++ b/tests/testresources/pyproject_python_missing_requires.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.docformatter]

--- a/tests/testresources/pyproject_python_old_requires.toml
+++ b/tests/testresources/pyproject_python_old_requires.toml
@@ -7,11 +7,11 @@ name="pyvelocity"
 version="0.1.0"
 description = "Checks code and settings and ls up advises in point of velocity."
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.15"
 classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.docformatter]

--- a/tests/testresources/pyproject_python_success.toml
+++ b/tests/testresources/pyproject_python_success.toml
@@ -17,6 +17,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.docformatter]

--- a/tests/testresources/pyproject_success.toml
+++ b/tests/testresources/pyproject_success.toml
@@ -34,6 +34,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed"
 ]
 

--- a/tests/testresources/pyproject_success_cli.toml
+++ b/tests/testresources/pyproject_success_cli.toml
@@ -34,6 +34,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed"
 ]
 


### PR DESCRIPTION
This pull request updates PyVelocity to support Python 3.14 as the latest version. All relevant constants, test cases, and test resources have been updated to reflect Python 3.14 support, replacing previous references to Python 3.13. This ensures that the tool and its tests are aligned with the latest Python release.

**Updates for Python 3.14 support:**

* Updated the `LATEST_PYTHON_VERSION` constant in `pyvelocity/constants.py` from "3.13" to "3.14".

**Test and classifier updates:**

* Updated all relevant test cases and expected outputs in `tests/checks/test_aggregation.py`, `tests/checks/test_classifiers.py`, `tests/checks/test_requires_python.py`, and `tests/configurations/files/sections/test_project.py` to include Python 3.14 and adjust logic for version checks. [[1]](diffhunk://#diff-0bbec606d6101a65d1b606abb4b901e079d509061abb81c0662e4e4014560867L34-R35) [[2]](diffhunk://#diff-6bc83d3d6c54f3146c90e77b4afe858772c7c1142b02d5ac7f8729da2f44629aL36-R36) [[3]](diffhunk://#diff-0f12926e15080de54aade1f9f47817de94a6a192f4d91a2bd1dd558e312ca494L31-R32) [[4]](diffhunk://#diff-0f12926e15080de54aade1f9f47817de94a6a192f4d91a2bd1dd558e312ca494L73-R83) [[5]](diffhunk://#diff-9913dfe92a947a8e2918f838cfb40d71c98ca9d509464ba50b66cdd11fb65126L36-R40) [[6]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL74-R75)

* Updated test resource files to add or replace classifiers for Python 3.14 in various `pyproject.toml` test files. [[1]](diffhunk://#diff-cb337fe90490f84ef778a55208637db19124bae5d800c4a289ae22b61cdaae94R19) [[2]](diffhunk://#diff-6c3a9f1cd8e59dd87f07f9e1d0e8897c038073e1494167b99355b13994259d46R17) [[3]](diffhunk://#diff-a1e86e033850e6fefe37c25b7762a092d2184f92db9f175bd8bbdf0845690690L13-R13) [[4]](diffhunk://#diff-e52e883e6555b691fac69c127faa1f02a95846a32529b9cad43e196bd7ef751bL10-R14) [[5]](diffhunk://#diff-69e98db630dc105a196880e28a2d18c40e2f8fe90efaa0df8442c1a64dae5f00R20) [[6]](diffhunk://#diff-d9879ec4bb1fc2a4f51d24513343cac2562d031ed389dd7a707bb4bd1fbb6d70R37) [[7]](diffhunk://#diff-b47c37c36b95873240b4d5a7b3d7de255cf22ddfee1ff7827972966fe223adddR37)