### PR TITLE
Update pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,66 +1,9 @@
 [dependency-groups]
 dev = [
-  "bandit",
-  "build",
   "bump-my-version",
-  "cohesion",
-  # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-  # so we should avoid 3.5.3 or lower.
-  # - Command: "pipenv install --skip-lock" fails 
-  #   since it tries to parse legacy package metadata and raise InstallError
-  #   · Issue #5595 · pypa/pipenv
-  #   https://github.com/pypa/pipenv/issues/5595
-  "coverage>=3.5.4",
-  # The dlint less than 0.14.0 limits max version of flake8.
-  # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-  #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-  "dlint>=0.14.0",
-  # We exclude docformatter versions before 1.7.8 because they depend on untokenize==0.1.1,
-  # whose setup.py uses ast.Constant.s that was removed in Python 3.14.
-  # docformatter 1.7.8 and later require Python 3.10 or later instead of untokenize.
-  # And, we specify as follows if the latest supported Python version is less than 3.11,
-  # so that docformatter can read the settings in pyproject.toml:
-  "docformatter[tomli]>=1.7.8; python_version < '3.11'",
-  "docformatter>=1.7.8; python_version >= '3.11'",
-  "dodgy",
-  # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-  # We should avoid the versions that is not compatible with the hacking,
-  # considering the speed of dependency calculation process
-  "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-  # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-  # - Using Black with other tools - Black 25.1.0 documentation
-  #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-  "flake8-bugbear",
-  # To use pyproject.toml for Flake8 configuration
-  "Flake8-pyproject",
-  # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-  # When unpin hacking, it has possibility to install too legacy version of hacking.
-  "hacking>=5.0.0",
-  "invokelint>=0.8.1",
-  "mypy",
-  "pylint",
-  "pytest",
+  "invokelint[basic]>=0.19.0",
   "pytest-resource-path",
-  "ruff",
-  # To prevent following error when running Semgrep due to legacy version of Semgrep
-  # Since the latest Semgrep depends on legacy version of clock:
-  #   File "/workspace/pyvelocity/.venv/lib/python3.14/site-packages/opentelemetry/proto/common/v1/common_pb2.py", line 5, in <module>
-  #     from google.protobuf import descriptor as _descriptor
-  #   File "/workspace/pyvelocity/.venv/lib/python3.14/site-packages/google/protobuf/descriptor.py", line 17, in <module>
-  #     from google.protobuf.internal import api_implementation
-  #   File "/workspace/pyvelocity/.venv/lib/python3.14/site-packages/google/protobuf/internal/api_implementation.py", line 51, in <module>
-  #     if _CanImport('google._upb._message'):
-  #        ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
-  #   File "/workspace/pyvelocity/.venv/lib/python3.14/site-packages/google/protobuf/internal/api_implementation.py", line 41, in _CanImport
-  #     mod = importlib.import_module(mod_name)
-  #   File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
-  #     return _bootstrap._gcd_import(name[level:], package, level)
-  #            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  #   TypeError: Metaclasses with custom tp_new are not supported.
-  "semgrep>=1.122.0",
-  # For setup.py
   "types-setuptools",
-  "types-invoke",
 ]
 [build-system]
 requires = ["setuptools"]
@@ -77,9 +20,7 @@ dependencies = [
   "packagediscovery>=0.2.0",
   "tomli",
   # To use TypeGuard
-  # Following definition causes mypy error in development environment (Pipenv issue.)
-  # typing-extensions = {version = "*", markers="python_version < '3.10.0'"}
-  "typing-extensions"
+  "typing-extensions;python_version<'3.10.0'",
 ]
 license = {file = "LICENSE"}
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,13 @@ external = [
     "DUO",  # dlint
     "H",    # Openstack/hacking
 ]
-select = ["ALL"]
+select = [
+  "ALL",
+    # Since compatible with PEP257, we can check docstring style by Ruff and don't need to consider about docstring style separately:
+  # - Should the first line of a Python function docstring be in imperative mood? (ruff / pydocstyle D401)
+  #   https://zenn.dev/y_shinoda/articles/pydocstyle-d401
+  "D401",    # First line should be in imperative mood
+]
 ignore = [
     # lint.pydocstyle
     # Reason: Docstring may be missed since docstring-min-length is set.


### PR DESCRIPTION
This pull request updates the development dependencies and linting configuration in `pyproject.toml` to streamline the dev environment and improve compatibility, especially with newer Python versions. The main changes include significant cleanup of the `dev` dependency group, a fix for `typing-extensions` version markers, and an update to the linting rules for docstring style.

**Dependency group cleanup and updates:**
- Major cleanup of the `dev` dependency group: removed many development tools (such as `bandit`, `build`, `cohesion`, `coverage`, `dlint`, `docformatter`, `dodgy`, `flake8`, `flake8-bugbear`, `Flake8-pyproject`, `hacking`, `mypy`, `pylint`, `pytest`, `ruff`, `semgrep`, and `types-invoke`), and replaced `invokelint` with `invokelint[basic]>=0.19.0` to simplify and modernize the development dependencies.

**Compatibility improvements:**
- Updated the `typing-extensions` dependency to only install for Python versions earlier than 3.10 by adding a version marker (`"typing-extensions;python_version<'3.10.0'"`), preventing unnecessary installation on newer Python versions.

**Linting configuration enhancements:**
- Modified the `select` list for linting rules to explicitly include `D401` (requiring the first line of a Python docstring to be in the imperative mood), leveraging Ruff’s compatibility with PEP257 for docstring style checks.